### PR TITLE
Support dump and passno settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ Manage NFS4 mounts.
 Role Variables
 --------------
 
-- `nfs_share_mounts`: List of dictionaries of NFS shares: `{ path: mount-point, mount: nfs server path, opts: mount options (optional) }`
 - `nfs_mount_opts`: Default NFS4 mount options
+- `nfs_share_mounts`: List of dictionaries of NFS shares:
+   - path: mount-point
+   - location: nfs server path
+   - opts: mount options (optional)
+   - dump: fs to dump (optional)
+   - passno: fs checks on reboot (optional)
 
 
 Example Playbook
@@ -23,6 +28,12 @@ Example Playbook
         - path: /mnt/readonly
           location: nfs.example.org:/read-only
           opts: "{{ nfs_mount_opts }},ro"
+        - path: /mnt/ex_passno
+          location: nfs.example.org:/ex_passno
+          passno: 0
+        - path: /mnt/ex_dump
+          location: nfs.example.org:/ex_dump
+          dump: 0
 
 
 Author Information

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,5 +18,7 @@
     name: "{{ item.path }}"
     opts: "{{ item.opts | default(nfs_mount_opts) }}"
     src: "{{ item.location }}"
+    dump: "{{ item.dump | default(omit) }}"
+    passno: "{{ item.passno | default(omit) }}"
     state: mounted
   with_items: "{{ nfs_share_mounts }}"


### PR DESCRIPTION
Omitted by default, these two settings match the fifth
and sixth fields from /etc/fstab (often, "0 0").

Propose: `1.1.0`