### PR TITLE
Support Ubuntu 18.04.1 LTS

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,14 @@
   yum:
     name: nfs-utils
     state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Install NFS mount utility
+  become: yes
+  apt:
+    pkg: nfs-common
+    state: latest
+  when: ansible_os_family == "Debian"
 
 # Do not create mountpoint using file, the mount module will create it
 # automatically. This avoids problems where the module tries to change


### PR DESCRIPTION
This commit allow us to manage NFS4 mounts on Ubuntu.

Reference: https://www.digitalocean.com/community/tutorials/how-to-set-up-an-nfs-mount-on-ubuntu-18-04