### PR TITLE
Ansible lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 install:
   # Install ansible
-  - pip install ansible
+  - pip install ansible ansible-lint
 
   # Check ansible version
   - ansible --version
@@ -24,6 +24,7 @@ install:
 script:
   # Basic role syntax check
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - ansible-lint .
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,9 @@ galaxy_info:
   - name: EL
     versions:
     - 7
+  - name: Ubuntu
+    versions:
+      - xenial
   galaxy_tags: []
 
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   become: yes
   apt:
     pkg: nfs-common
-    state: latest
+    state: present
   when: ansible_os_family == "Debian"
 
 # Do not create mountpoint using file, the mount module will create it


### PR DESCRIPTION
Adding linting which should pick up

```
ansible-role-nfs-mount jamoore$ ansible-lint .
[ANSIBLE0010] Package installs should not use latest
/opt/own-ansible/ansible-role-nfs-mount/tasks/main.yml:11
Task/Handler: Install NFS mount utility
```

at which point the conversation started in https://github.com/openmicroscopy/ansible-role-nfs-mount/pull/2#discussion_r214810581 can be continued.